### PR TITLE
lib.py: Handle versions newer than 2016.1 properly as well.

### DIFF
--- a/dolfinh5tools/lib.py
+++ b/dolfinh5tools/lib.py
@@ -44,7 +44,7 @@ class Create(object):
             self.functionspace.ufl_element().family()
         self.fieldsDict[field_name]['metadata']['degree'] = \
             self.functionspace.ufl_element().degree()
-        if df.__version__ == '2016.1.0':
+        if df.__version__ >= '2016.1.0':
             print df.__version__
             condition = isinstance(self.functionspace, df.FunctionSpace) and \
                         self.functionspace.num_sub_spaces() > 0


### PR DESCRIPTION
Fixes TestField.test_save_hdf5.

Started out with an overkill variant to avoid the usual pitfalls of 
lexical sorting, but this should already to the trick.